### PR TITLE
Add option to include image width/height

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,28 @@ md.render(`![](example.png "image title")`);
 // <p><img src="example.png" alt="" title="image title" loading="lazy"></p>\n
 ```
 
+The plugin can also add `width` and `height` attributes to each image. This can prevent [cumulative layout shifts (CLS)](https://web.dev/cls/):
+
+```javascript
+md.use(lazy_loading, {
+    image_size: true,
+
+    // Where your images are stored
+    base_path: __dirname + 'src/', 
+});
+
+md.render(`![](example.png "image title")`);
+// <p><img src="example.png" alt="" title="image title" loading="lazy" width="100" height="100"></p>\n
+```
+
+To keep images responsive, also include the following CSS:
+```css
+img{
+    max-width: 100%;
+    height: auto;
+}
+```
+
 ## License
 
 MIT

--- a/index.js
+++ b/index.js
@@ -1,11 +1,24 @@
 'use strict';
 
-module.exports = function lazy_loading_plugin(md, options) {
+module.exports = function lazy_loading_plugin(md, mdOptions) {
   var defaultImageRenderer = md.renderer.rules.image;
 
   md.renderer.rules.image = function (tokens, idx, options, env, self) {
     var token = tokens[idx];
     token.attrSet('loading', 'lazy');
+
+    if(mdOptions && mdOptions.base_path && mdOptions.image_size === true){
+      const sizeOf = require('image-size');
+      const path = require('path');
+
+      const imgSrc = token.attrGet('src');
+      const imgPath = path.join(mdOptions.base_path, imgSrc);
+      const dimensions = sizeOf(imgPath);
+      
+      token.attrSet('width', dimensions.width);
+      token.attrSet('height', dimensions.height);
+    }
+
     return defaultImageRenderer(tokens, idx, options, env, self);
   };
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "repository": "https://github.com/ruanyf/markdown-it-image-lazy-loading.git",
   "license": "MIT",
   "devDependencies": {
+    "image-size": "^1.0.0",
     "markdown-it": "^9.1.0",
     "tape": "^4.11.0"
   }


### PR DESCRIPTION
Lazy loading images without setting a width/height can cause layout shifts.
Google now penalizes websites with a lot of layout shifts (web vitals).